### PR TITLE
mature/profanity updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-src/generated/prisma
-generated/prisma
+prisma/generated
 
 .idea/dataSources.xml
 

--- a/prisma/migrations/20260330120000_user_blur_profanity_listing_images/migration.sql
+++ b/prisma/migrations/20260330120000_user_blur_profanity_listing_images/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN "blurProfanityApprovedListingImages" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20260330200000_user_allow_mature_listing_content/migration.sql
+++ b/prisma/migrations/20260330200000_user_allow_mature_listing_content/migration.sql
@@ -1,0 +1,17 @@
+-- Opt-in to see moderator-cleared profanity listings in full (18+). Replaces blur-only column when present.
+ALTER TABLE "user" ADD COLUMN "allowMatureListingContent" BOOLEAN NOT NULL DEFAULT false;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'user'
+          AND column_name = 'blurProfanityApprovedListingImages'
+    ) THEN
+        UPDATE "user"
+        SET "allowMatureListingContent" = NOT COALESCE("blurProfanityApprovedListingImages", true);
+        ALTER TABLE "user" DROP COLUMN "blurProfanityApprovedListingImages";
+    END IF;
+END $$;

--- a/prisma/migrations/20260331100000_profanity_moderation_terms/migration.sql
+++ b/prisma/migrations/20260331100000_profanity_moderation_terms/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "ProfanityListType" AS ENUM ('WHITELIST', 'BLACKLIST');
+
+-- CreateTable
+CREATE TABLE "profanity_moderation_term" (
+    "id" TEXT NOT NULL,
+    "listType" "ProfanityListType" NOT NULL,
+    "term" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" TEXT,
+
+    CONSTRAINT "profanity_moderation_term_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "profanity_moderation_term_listType_term_key" ON "profanity_moderation_term"("listType", "term");
+
+-- CreateIndex
+CREATE INDEX "profanity_moderation_term_listType_idx" ON "profanity_moderation_term"("listType");
+
+-- AddForeignKey
+ALTER TABLE "profanity_moderation_term" ADD CONSTRAINT "profanity_moderation_term_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,9 @@ model User {
     listingProfanityFlags    ListingProfanityFlag[] @relation("ListingProfanityOwner")
     listingProfanityReviews  ListingProfanityFlag[] @relation("ListingProfanityReviewer")
     savedQueries             SavedQuery[]
+    /// When true, the viewer opts in to see moderator-cleared profanity listings with original wording and unblurred images (18+).
+    allowMatureListingContent Boolean @default(false)
+    profanityModerationTermsCreated ProfanityModerationTerm[]
 
     @@map("user")
 }
@@ -282,6 +285,24 @@ model ListingProfanityFlag {
     @@index([listingId])
     @@index([ownerId])
     @@map("listing_profanity_flag")
+}
+
+enum ProfanityListType {
+    WHITELIST
+    BLACKLIST
+}
+
+model ProfanityModerationTerm {
+    id            String            @id @default(cuid())
+    listType      ProfanityListType
+    term          String
+    createdAt     DateTime          @default(now())
+    createdById   String?
+    creator       User?             @relation(fields: [createdById], references: [id], onDelete: SetNull)
+
+    @@unique([listType, term])
+    @@index([listType])
+    @@map("profanity_moderation_term")
 }
 
 model Verification {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,7 @@ generator client {
     provider        = "prisma-client-js"
     previewFeatures = ["fullTextSearchPostgres"]
     binaryTargets   = ["native", "rhel-openssl-3.0.x"]
+    output          = "./generated"
 }
 
 datasource db {
@@ -20,30 +21,30 @@ datasource db {
 // -------- User Schema --------
 
 model User {
-    id                       String                    @id
-    email                    String                    @unique
-    name                     String
-    emailVerified            Boolean                   @default(false)
-    listingApproved          Boolean                   @default(false)
-    image                    String?
-    createdAt                DateTime                  @default(now())
-    updatedAt                DateTime                  @default(now()) @updatedAt
-    sessions                 Session[]
-    accounts                 Account[]
-    listings                 Listing[]
-    role                     UserRole                  @default(STUDENT)
-    statuses                 UserStatus[]
-    reports                  Report[]
-    conversationParticipants ConversationParticipant[]
-    sentMessages             Message[]
-    events                   ListingEvent[]
-    profanityFlagsSent       MessageProfanityFlag[] @relation("ProfanityFlagSender")
-    profanityFlagsReviewed   MessageProfanityFlag[] @relation("ProfanityFlagReviewer")
-    listingProfanityFlags    ListingProfanityFlag[] @relation("ListingProfanityOwner")
-    listingProfanityReviews  ListingProfanityFlag[] @relation("ListingProfanityReviewer")
-    savedQueries             SavedQuery[]
+    id                              String                    @id
+    email                           String                    @unique
+    name                            String
+    emailVerified                   Boolean                   @default(false)
+    listingApproved                 Boolean                   @default(false)
+    image                           String?
+    createdAt                       DateTime                  @default(now())
+    updatedAt                       DateTime                  @default(now()) @updatedAt
+    sessions                        Session[]
+    accounts                        Account[]
+    listings                        Listing[]
+    role                            UserRole                  @default(STUDENT)
+    statuses                        UserStatus[]
+    reports                         Report[]
+    conversationParticipants        ConversationParticipant[]
+    sentMessages                    Message[]
+    events                          ListingEvent[]
+    profanityFlagsSent              MessageProfanityFlag[]    @relation("ProfanityFlagSender")
+    profanityFlagsReviewed          MessageProfanityFlag[]    @relation("ProfanityFlagReviewer")
+    listingProfanityFlags           ListingProfanityFlag[]    @relation("ListingProfanityOwner")
+    listingProfanityReviews         ListingProfanityFlag[]    @relation("ListingProfanityReviewer")
+    savedQueries                    SavedQuery[]
     /// When true, the viewer opts in to see moderator-cleared profanity listings with original wording and unblurred images (18+).
-    allowMatureListingContent Boolean @default(false)
+    allowMatureListingContent       Boolean                   @default(false)
     profanityModerationTermsCreated ProfanityModerationTerm[]
 
     @@map("user")
@@ -117,10 +118,10 @@ enum ImageType {
 }
 
 model Category {
-    id       Int       @id @default(autoincrement())
-    name     String    @unique
-    slug     String    @unique
-    listings Listing[]
+    id           Int                    @id @default(autoincrement())
+    name         String                 @unique
+    slug         String                 @unique
+    listings     Listing[]
     savedQueries CategoryOnSavedQuery[]
 }
 
@@ -267,12 +268,12 @@ model MessageProfanityFlag {
 }
 
 model ListingProfanityFlag {
-    id                  String                   @id @default(cuid())
+    id                  String                     @id @default(cuid())
     listingId           String
     ownerId             String
     originalTitle       String
     originalDescription String
-    createdAt           DateTime                 @default(now())
+    createdAt           DateTime                   @default(now())
     status              MessageProfanityFlagStatus @default(PENDING)
     reviewedAt          DateTime?
     reviewedById        String?
@@ -293,12 +294,12 @@ enum ProfanityListType {
 }
 
 model ProfanityModerationTerm {
-    id            String            @id @default(cuid())
-    listType      ProfanityListType
-    term          String
-    createdAt     DateTime          @default(now())
-    createdById   String?
-    creator       User?             @relation(fields: [createdById], references: [id], onDelete: SetNull)
+    id          String            @id @default(cuid())
+    listType    ProfanityListType
+    term        String
+    createdAt   DateTime          @default(now())
+    createdById String?
+    creator     User?             @relation(fields: [createdById], references: [id], onDelete: SetNull)
 
     @@unique([listType, term])
     @@index([listType])
@@ -342,16 +343,16 @@ enum EventType {
 // -------- Saved Queries / Search Alerts --------
 
 model SavedQuery {
-    id        String   @id @default(cuid())
-    userId    String
-    name      String
-    searchTerm String?
-    categories CategoryOnSavedQuery[]
-    minPrice  Decimal? @db.Decimal(10, 2)
-    maxPrice  Decimal? @db.Decimal(10, 2)
-    enabled   Boolean  @default(true)
-    createdAt DateTime @default(now())
-    updatedAt DateTime @default(now()) @updatedAt
+    id              String                 @id @default(cuid())
+    userId          String
+    name            String
+    searchTerm      String?
+    categories      CategoryOnSavedQuery[]
+    minPrice        Decimal?               @db.Decimal(10, 2)
+    maxPrice        Decimal?               @db.Decimal(10, 2)
+    enabled         Boolean                @default(true)
+    createdAt       DateTime               @default(now())
+    updatedAt       DateTime               @default(now()) @updatedAt
     lastEmailSentAt DateTime?
 
     user User @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -373,12 +374,12 @@ model CategoryOnSavedQuery {
 }
 
 model QueryNotificationLog {
-    id        String   @id @default(cuid())
-    queryId   String
-    sentAt    DateTime @default(now())
-    listingCount Int
+    id             String   @id @default(cuid())
+    queryId        String
+    sentAt         DateTime @default(now())
+    listingCount   Int
     recipientEmail String
-    status    String   @default("sent")
+    status         String   @default("sent")
 
     @@index([queryId])
     @@index([sentAt])

--- a/src/actions/admin-actions.ts
+++ b/src/actions/admin-actions.ts
@@ -22,7 +22,7 @@ export async function getAdminStats() {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -70,7 +70,7 @@ export async function getRecentlyListedItems(limit: number = 5, skip: number = 0
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -123,7 +123,7 @@ export async function getPendingListingApprovals(
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -192,7 +192,7 @@ export async function getAllUsers(limit: number = 50, skip: number = 0) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -230,7 +230,7 @@ export async function approveFirstListing(listingId: string) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -291,7 +291,7 @@ export async function rejectFirstListing(listingId: string) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -314,7 +314,7 @@ export async function getPendingListingReports(limit: number = 50, skip: number 
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -403,7 +403,7 @@ export async function getReportById(reportId: string) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -439,7 +439,7 @@ export async function deleteListing(listingId: string) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -462,7 +462,7 @@ export async function suspendUserWithExpiry(userId: string, expiresAt: Date) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -488,7 +488,7 @@ export async function banUserPermanently(userId: string) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -514,7 +514,7 @@ export async function activateUser(userId: string) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -540,7 +540,7 @@ export async function getUserSuspensionStatus(userId: string) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -575,7 +575,7 @@ export async function getSuspendedUsers(limit: number = 50, skip: number = 0) {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -635,7 +635,7 @@ export async function resolveReport(reportId: string, action: 'RESOLVED' | 'DISM
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -679,7 +679,7 @@ export async function getPendingProfanityFlags(limit: number = 25, skip: number 
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -734,7 +734,7 @@ export async function reviewProfanityFlag(
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -788,7 +788,7 @@ export async function getPendingListingProfanityFlags(
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -839,7 +839,7 @@ export async function reviewListingProfanityFlag(
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -910,7 +910,7 @@ export async function getProfanityModerationTerms(): Promise<ProfanityModeration
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -938,7 +938,7 @@ export async function addProfanityModerationTerm(
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -975,7 +975,7 @@ export async function deleteProfanityModerationTerm(id: string): Promise<{ succe
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();

--- a/src/actions/admin-actions.ts
+++ b/src/actions/admin-actions.ts
@@ -1,12 +1,19 @@
 "use server";
 
 import { auth } from "@/lib/auth";
-import { ListingStatus, MessageProfanityFlagStatus, ReportStatus, UserStatusType } from "@prisma/client";
+import {
+    ListingStatus,
+    MessageProfanityFlagStatus,
+    ProfanityListType,
+    ReportStatus,
+    UserStatusType,
+} from "@prisma/client";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { getCurrentUserRole } from "@/actions/user-actions";
 import { prisma } from "@/lib/prisma";
+import { invalidateProfanityModerationTermCache } from "@/lib/profanity-moderation-db";
 
 export async function getAdminStats() {
     // Validate session and admin role
@@ -104,8 +111,13 @@ export async function getRecentlyListedItems(limit: number = 5, skip: number = 0
     }));
 }
 
-export async function getFirstListingsAwaitingApproval(limit: number = 10, skip: number = 0) {
-    // Validate session and admin role
+export type PendingApprovalSort = "oldest" | "newest";
+
+export async function getPendingListingApprovals(
+    limit: number = 10,
+    skip: number = 0,
+    sort: PendingApprovalSort = "oldest"
+) {
     const session = await auth.api.getSession({
         headers: await headers()
     });
@@ -119,13 +131,16 @@ export async function getFirstListingsAwaitingApproval(limit: number = 10, skip:
         throw new Error("Unauthorized");
     }
 
-    // Get users' first listings (DRAFT status)
-    const firstListings = await prisma.listing.findMany({
+    const listings = await prisma.listing.findMany({
         where: {
-            listingStatus: ListingStatus.DRAFT
+            listingStatus: ListingStatus.DRAFT,
+            OR: [
+                { owner: { listingApproved: false } },
+                { listingProfanityFlags: { some: { status: MessageProfanityFlagStatus.PENDING } } },
+            ],
         },
         orderBy: {
-            createdAt: 'asc'
+            createdAt: sort === "newest" ? "desc" : "asc",
         },
         take: limit,
         skip: skip,
@@ -135,22 +150,39 @@ export async function getFirstListingsAwaitingApproval(limit: number = 10, skip:
                     id: true,
                     email: true,
                     name: true,
-                    createdAt: true
+                    listingApproved: true,
                 }
             },
-            categories: true
+            categories: true,
+            listingProfanityFlags: {
+                where: { status: MessageProfanityFlagStatus.PENDING },
+                select: { id: true },
+                take: 1,
+            },
         }
     });
 
-    return firstListings.map(listing => ({
-        id: listing.id,
-        title: listing.title,
-        seller: listing.owner.email,
-        sellerName: listing.owner.name,
-        category: listing.categories[0]?.name || 'Uncategorized',
-        price: `$${listing.price.toNumber().toFixed(2)}`,
-        date: listing.createdAt.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
-    }));
+    return listings.map(listing => {
+        const isFirstListingPending = !listing.owner.listingApproved;
+        const isProfanityPending = listing.listingProfanityFlags.length > 0;
+        const pendingReason =
+            isFirstListingPending && isProfanityPending
+                ? "BOTH"
+                : isProfanityPending
+                    ? "PROFANITY"
+                    : "FIRST_LISTING";
+
+        return {
+            id: listing.id,
+            title: listing.title,
+            seller: listing.owner.email,
+            sellerName: listing.owner.name,
+            category: listing.categories[0]?.name || "Uncategorized",
+            price: `$${listing.price.toNumber().toFixed(2)}`,
+            date: listing.createdAt.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }),
+            pendingReason,
+        };
+    });
 }
 
 export async function getAllUsers(limit: number = 50, skip: number = 0) {
@@ -215,16 +247,39 @@ export async function approveFirstListing(listingId: string) {
         throw new Error("Listing not found");
     }
 
-    await prisma.$transaction([
-        prisma.listing.update({
+    await prisma.$transaction(async (tx) => {
+        const pendingProfanity = await tx.listingProfanityFlag.findFirst({
+            where: {
+                listingId,
+                status: MessageProfanityFlagStatus.PENDING,
+            },
+        });
+
+        if (pendingProfanity) {
+            await tx.listingProfanityFlag.update({
+                where: { id: pendingProfanity.id },
+                data: {
+                    status: MessageProfanityFlagStatus.REVIEWED_NO_ACTION,
+                    reviewedAt: new Date(),
+                    reviewedById: session.user.id,
+                },
+            });
+        }
+
+        await tx.listing.update({
             where: { id: listingId },
-            data: { listingStatus: ListingStatus.AVAILABLE }
-        }),
-        prisma.user.update({
+            data: { listingStatus: ListingStatus.AVAILABLE },
+        });
+
+        await tx.user.update({
             where: { id: listing.ownerId },
             data: { listingApproved: true },
-        }),
-    ]);
+        });
+    });
+
+    revalidatePath(`/market/listing/${listingId}`);
+    revalidatePath("/market");
+    revalidatePath("/admin");
 
     return { success: true };
 }
@@ -718,9 +773,12 @@ export interface ListingProfanityFlagRow {
     createdAt: Date;
 }
 
+export type ListingProfanityQueueSort = "newest" | "oldest";
+
 export async function getPendingListingProfanityFlags(
     limit: number = 25,
-    skip: number = 0
+    skip: number = 0,
+    sortOrder: ListingProfanityQueueSort = "newest"
 ): Promise<{
     flags: ListingProfanityFlagRow[];
     total: number;
@@ -738,10 +796,12 @@ export async function getPendingListingProfanityFlags(
         throw new Error("Unauthorized");
     }
 
+    const createdAtOrder = sortOrder === "newest" ? ("desc" as const) : ("asc" as const);
+
     const [rows, total] = await Promise.all([
         prisma.listingProfanityFlag.findMany({
             where: { status: MessageProfanityFlagStatus.PENDING },
-            orderBy: { createdAt: "desc" },
+            orderBy: { createdAt: createdAtOrder },
             take: limit,
             skip,
             include: {
@@ -792,15 +852,143 @@ export async function reviewListingProfanityFlag(
             ? MessageProfanityFlagStatus.ACTIONED
             : MessageProfanityFlagStatus.REVIEWED_NO_ACTION;
 
-    await prisma.listingProfanityFlag.update({
+    const flag = await prisma.listingProfanityFlag.findUnique({
         where: { id: flagId },
-        data: {
-            status,
-            reviewedAt: new Date(),
-            reviewedById: session.user.id,
-        },
+        select: { listingId: true },
     });
 
+    if (!flag) {
+        throw new Error("Flag not found");
+    }
+
+    await prisma.$transaction(async (tx) => {
+        await tx.listingProfanityFlag.update({
+            where: { id: flagId },
+            data: {
+                status,
+                reviewedAt: new Date(),
+                reviewedById: session.user.id,
+            },
+        });
+
+        if (outcome === "REVIEWED_NO_ACTION") {
+            const listing = await tx.listing.findUnique({
+                where: { id: flag.listingId },
+                select: { ownerId: true, listingStatus: true },
+            });
+            if (listing?.listingStatus === ListingStatus.DRAFT) {
+                const owner = await tx.user.findUnique({
+                    where: { id: listing.ownerId },
+                    select: { listingApproved: true },
+                });
+                if (owner?.listingApproved) {
+                    await tx.listing.update({
+                        where: { id: flag.listingId },
+                        data: { listingStatus: ListingStatus.AVAILABLE },
+                    });
+                }
+            }
+        }
+    });
+
+    revalidatePath("/admin");
+    revalidatePath(`/market/listing/${flag.listingId}`);
+    revalidatePath("/market");
+    return { success: true };
+}
+
+export interface ProfanityModerationTermRow {
+    id: string;
+    listType: ProfanityListType;
+    term: string;
+    createdAt: Date;
+}
+
+export async function getProfanityModerationTerms(): Promise<ProfanityModerationTermRow[]> {
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    });
+
+    if (!session) {
+        redirect("/sign-in");
+    }
+
+    const userRole = await getCurrentUserRole();
+    if (userRole !== "ADMIN") {
+        throw new Error("Unauthorized");
+    }
+
+    return prisma.profanityModerationTerm.findMany({
+        orderBy: [{ listType: "asc" }, { term: "asc" }],
+        select: {
+            id: true,
+            listType: true,
+            term: true,
+            createdAt: true,
+        },
+    });
+}
+
+export async function addProfanityModerationTerm(
+    listType: ProfanityListType,
+    rawTerm: string
+): Promise<{ success: boolean; error?: string }> {
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    });
+
+    if (!session) {
+        redirect("/sign-in");
+    }
+
+    const userRole = await getCurrentUserRole();
+    if (userRole !== "ADMIN") {
+        throw new Error("Unauthorized");
+    }
+
+    const term = rawTerm.trim().toLowerCase();
+    if (term.length < 2 || term.length > 120) {
+        return { success: false, error: "Enter a term between 2 and 120 characters." };
+    }
+
+    try {
+        await prisma.profanityModerationTerm.create({
+            data: {
+                listType,
+                term,
+                createdById: session.user.id,
+            },
+        });
+    } catch {
+        return { success: false, error: "That term is already in this list." };
+    }
+
+    invalidateProfanityModerationTermCache();
+    revalidatePath("/admin/profanity");
+    revalidatePath("/admin");
+    return { success: true };
+}
+
+export async function deleteProfanityModerationTerm(id: string): Promise<{ success: boolean }> {
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    });
+
+    if (!session) {
+        redirect("/sign-in");
+    }
+
+    const userRole = await getCurrentUserRole();
+    if (userRole !== "ADMIN") {
+        throw new Error("Unauthorized");
+    }
+
+    await prisma.profanityModerationTerm.deleteMany({
+        where: { id },
+    });
+
+    invalidateProfanityModerationTermCache();
+    revalidatePath("/admin/profanity");
     revalidatePath("/admin");
     return { success: true };
 }

--- a/src/actions/category-actions.ts
+++ b/src/actions/category-actions.ts
@@ -48,7 +48,7 @@ async function requireAdminSession() {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const currentUserRole = await getCurrentUserRole();

--- a/src/actions/chat-actions.ts
+++ b/src/actions/chat-actions.ts
@@ -2,6 +2,7 @@
 
 import { auth, prisma } from "@/lib/auth";
 import { censorProfanity } from "@/lib/profanity-filter";
+import { getProfanityModerationTermLists } from "@/lib/profanity-moderation-db";
 import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
 
@@ -269,7 +270,11 @@ export async function sendMessage(conversationId: string, body: string): Promise
     if (!trimmed) throw new Error("Message cannot be empty");
     if (trimmed.length > 2000) throw new Error("Message too long");
 
-    const { censored: bodyToStore, wasCensored } = censorProfanity(trimmed);
+    const { whitelist, blacklist } = await getProfanityModerationTermLists();
+    const { censored: bodyToStore, wasCensored } = censorProfanity(trimmed, {
+        whitelist,
+        blacklist,
+    });
 
     // Verify user is a participant
     const participant = await prisma.conversationParticipant.findUnique({

--- a/src/actions/listing-actions.ts
+++ b/src/actions/listing-actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import {auth} from "@/lib/auth";
-import {$Enums} from "@prisma/client";
+import {$Enums, MessageProfanityFlagStatus} from "@prisma/client";
 import {headers} from "next/headers";
 import {redirect} from "next/navigation";
 import {getCurrentUserRole} from "@/actions/user-actions";
@@ -12,6 +12,71 @@ import {ListingFilters} from "@/types/ListingFilters";
 import {ListingUtils} from "@/utils/ListingUtils";
 import { enforceUserStatus, checkUserStatus } from "@/utils/StatusEnforcer";
 import { prisma } from "@/lib/prisma";
+
+async function withProfanityViewerFields(
+    listings: ListingWithRelations[],
+    viewerId: string,
+    getRowExtras: (
+        listing: ListingWithRelations
+    ) => Pick<ListingObject, "isPendingApproval" | "isDeniedByAdmin">
+): Promise<ListingObject[]> {
+    if (listings.length === 0) {
+        return [];
+    }
+
+    const viewer = await prisma.user.findUnique({
+        where: { id: viewerId },
+        select: { allowMatureListingContent: true },
+    });
+    const allowMature = viewer?.allowMatureListingContent ?? false;
+
+    const ids = listings.map((l) => l.id);
+    const flags = await prisma.listingProfanityFlag.findMany({
+        where: {
+            listingId: { in: ids },
+            status: MessageProfanityFlagStatus.REVIEWED_NO_ACTION,
+        },
+        orderBy: [{ reviewedAt: "desc" }, { createdAt: "desc" }],
+        select: {
+            listingId: true,
+            originalTitle: true,
+            originalDescription: true,
+        },
+    });
+
+    const releasedByListing = new Map<string, { title: string; description: string }>();
+    for (const f of flags) {
+        if (!releasedByListing.has(f.listingId)) {
+            releasedByListing.set(f.listingId, {
+                title: f.originalTitle,
+                description: f.originalDescription,
+            });
+        }
+    }
+
+    return listings.map((listing) => {
+        const extras = getRowExtras(listing);
+        const base: ListingObject = {
+            ...listing,
+            price: listing.price.toNumber(),
+            ...extras,
+        };
+        const released = releasedByListing.get(listing.id);
+        if (!released) {
+            return base;
+        }
+        return {
+            ...base,
+            ...(allowMature
+                ? {
+                      matureAlternateTitle: released.title,
+                      matureAlternateDescription: released.description,
+                  }
+                : {}),
+            blurProfanityReleasedCardImage: !allowMature,
+        };
+    });
+}
 
 /**
  * Returns all listings based on listing status and current user's role.
@@ -85,12 +150,18 @@ export async function getListings(
             }
         });
 
-        return listings.map(listing => ({
-            ...listing,
-            price: listing.price.toNumber(),
-            isPendingApproval: listing.listingStatus === ListingStatus.DRAFT && !currentUser?.listingApproved,
-            isDeniedByAdmin: listing.listingStatus === ListingStatus.ARCHIVED && !currentUser?.listingApproved,
-        }));
+        return withProfanityViewerFields(
+            listings,
+            session.user.id,
+            (listing) => ({
+                isPendingApproval:
+                    listing.listingStatus === ListingStatus.DRAFT &&
+                    !currentUser?.listingApproved,
+                isDeniedByAdmin:
+                    listing.listingStatus === ListingStatus.ARCHIVED &&
+                    !currentUser?.listingApproved,
+            })
+        );
     }
 
     if (currentUserRole === UserRole.FACULTY || currentUserRole === UserRole.ADMIN) {
@@ -136,11 +207,8 @@ export async function getListings(
         });
     }
 
-    // Convert and return listings
-    return listings.map(listing => ({
-            ...listing,
-            price: listing.price.toNumber(),
-            isPendingApproval: false,
-            isDeniedByAdmin: false,
+    return withProfanityViewerFields(listings, session.user.id, () => ({
+        isPendingApproval: false,
+        isDeniedByAdmin: false,
     }));
 }

--- a/src/actions/listing-actions.ts
+++ b/src/actions/listing-actions.ts
@@ -99,7 +99,7 @@ export async function getListings(
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     // Enforce user status - allow viewing listings even if suspended

--- a/src/actions/listing-create.ts
+++ b/src/actions/listing-create.ts
@@ -11,6 +11,7 @@ import { enforceUserStatus } from "@/utils/StatusEnforcer";
 import { getCurrentUserRole } from "@/actions/user-actions";
 import { prisma } from "@/lib/prisma";
 import { censorProfanity } from "@/lib/profanity-filter";
+import { getProfanityModerationTermLists } from "@/lib/profanity-moderation-db";
 import { revalidatePath } from "next/cache";
 
 const CreateListingRequest = z.object({
@@ -85,6 +86,7 @@ export async function createListingAction(_initialState: FormResponse, formData:
 
     let newListingId: string;
     let requiresAdminApproval = false;
+    let pendingReason: "profanity" | "first_listing" | "both" | null = null;
 
     try {
         const user = await prisma.user.findUnique({
@@ -145,12 +147,18 @@ export async function createListingAction(_initialState: FormResponse, formData:
         // Censored title/description; DRAFT if profanity or user requires approval; optional profanity flag row.
         const rawTitle = parsedFormData.data.title.trim();
         const rawDescription = parsedFormData.data.description.trim();
-        const titleC = censorProfanity(rawTitle);
-        const descC = censorProfanity(rawDescription);
+        const { whitelist, blacklist } = await getProfanityModerationTermLists();
+        const titleC = censorProfanity(rawTitle, { whitelist, blacklist });
+        const descC = censorProfanity(rawDescription, { whitelist, blacklist });
         const wasCensored = titleC.wasCensored || descC.wasCensored;
 
         const listingStatus =
             wasCensored || !user.listingApproved ? "DRAFT" : "AVAILABLE";
+        if (listingStatus === "DRAFT") {
+            if (wasCensored && !user.listingApproved) pendingReason = "both";
+            else if (wasCensored) pendingReason = "profanity";
+            else pendingReason = "first_listing";
+        }
 
         const newListing = await prisma.$transaction(async (tx) => {
             const listing = await tx.listing.create({
@@ -205,5 +213,6 @@ export async function createListingAction(_initialState: FormResponse, formData:
     }
 
     // Redirect after successful creation (outside try-catch)
-    redirect(`/market/listing/${newListingId}?created=true${requiresAdminApproval ? "&requiresApproval=true" : ""}`);
+    const pendingReasonParam = pendingReason ? `&pendingReason=${pendingReason}` : "";
+    redirect(`/market/listing/${newListingId}?created=true${requiresAdminApproval ? "&requiresApproval=true" : ""}${pendingReasonParam}`);
 }

--- a/src/actions/listing-profanity-preview.ts
+++ b/src/actions/listing-profanity-preview.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { censorProfanity } from "@/lib/profanity-filter";
+import { getProfanityModerationTermLists } from "@/lib/profanity-moderation-db";
+
+export type ListingProfanityPreview = {
+    titleMatches: string[];
+    descriptionMatches: string[];
+    willHoldForReview: boolean;
+};
+
+/**
+ * Live preview for the listing form: which filter patterns match and whether the listing would be held for review.
+ */
+export async function previewListingProfanityForForm(
+    title: string,
+    description: string
+): Promise<ListingProfanityPreview> {
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    });
+
+    if (!session?.user) {
+        return { titleMatches: [], descriptionMatches: [], willHoldForReview: false };
+    }
+
+    const { whitelist, blacklist } = await getProfanityModerationTermLists();
+
+    const titleR = censorProfanity(title.trim(), {
+        whitelist,
+        blacklist,
+        collectMatches: true,
+    });
+    const descR = censorProfanity(description.trim(), {
+        whitelist,
+        blacklist,
+        collectMatches: true,
+    });
+
+    return {
+        titleMatches: titleR.matches ?? [],
+        descriptionMatches: descR.matches ?? [],
+        willHoldForReview: titleR.wasCensored || descR.wasCensored,
+    };
+}

--- a/src/actions/listing-reports.ts
+++ b/src/actions/listing-reports.ts
@@ -6,6 +6,7 @@ import { CreateReportSchema, CreateReportInput } from "@/schemas/report-schemas"
 import { enforceUserStatus } from "@/utils/StatusEnforcer";
 import { prisma } from "@/lib/prisma";
 import { censorProfanity } from "@/lib/profanity-filter";
+import { getProfanityModerationTermLists } from "@/lib/profanity-moderation-db";
 import { revalidatePath } from "next/cache";
 
 interface SubmitReportResult {
@@ -58,8 +59,9 @@ export async function submitListingReport(
         }
 
         const { listingId, reason, details: rawDetails } = validationResult.data;
+        const { whitelist, blacklist } = await getProfanityModerationTermLists();
         const detailsCensored = rawDetails?.trim()
-            ? censorProfanity(rawDetails.trim()).censored
+            ? censorProfanity(rawDetails.trim(), { whitelist, blacklist }).censored
             : null;
 
         // Check if listing exists

--- a/src/actions/listing-update.ts
+++ b/src/actions/listing-update.ts
@@ -10,6 +10,7 @@ import { redirect } from "next/navigation";
 import { getCurrentUserRole } from "@/actions/user-actions";
 import { prisma } from "@/lib/prisma";
 import { censorProfanity } from "@/lib/profanity-filter";
+import { getProfanityModerationTermLists } from "@/lib/profanity-moderation-db";
 import { revalidatePath } from "next/cache";
 import { MessageProfanityFlagStatus } from "@prisma/client";
 
@@ -115,8 +116,9 @@ export async function updateListingAction(_initialState: FormResponse, formData:
 
         const rawTitle = parsedFormData.data.title.trim();
         const rawDescription = parsedFormData.data.description.trim();
-        const titleC = censorProfanity(rawTitle);
-        const descC = censorProfanity(rawDescription);
+        const { whitelist, blacklist } = await getProfanityModerationTermLists();
+        const titleC = censorProfanity(rawTitle, { whitelist, blacklist });
+        const descC = censorProfanity(rawDescription, { whitelist, blacklist });
         const wasCensored = titleC.wasCensored || descC.wasCensored;
 
         const updateData: Prisma.ListingUpdateInput = {

--- a/src/actions/user-actions.ts
+++ b/src/actions/user-actions.ts
@@ -7,7 +7,6 @@ import { revalidatePath } from "next/cache";
 import { $Enums } from "@prisma/client";
 import UserRole = $Enums.UserRole;
 import UserStatusType = $Enums.UserStatusType;
-import { enforceUserStatus } from "@/utils/StatusEnforcer";
 import { prisma } from "@/lib/prisma";
 
 /**
@@ -22,12 +21,14 @@ export async function updateAllowMatureListingContentPreference(
     });
 
     if (!session?.user) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     await prisma.user.update({
         where: { id: session.user.id },
-        data: { allowMatureListingContent },
+        data: {
+            allowMatureListingContent: allowMatureListingContent
+        }
     });
 
     revalidatePath("/profile");
@@ -42,7 +43,7 @@ export async function getCurrentUserRole(): Promise<$Enums.UserRole> {
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const user = await prisma.user.findFirst({
@@ -64,7 +65,7 @@ export async function updateAdminUser(userId: string, data: { name?: string; ema
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     const userRole = await getCurrentUserRole();
@@ -100,7 +101,7 @@ export async function getUserStatus(userId: string): Promise<{status: number, us
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     // Get role of current user and validate
@@ -156,7 +157,7 @@ async function createUserStatus(userId: string, userStatus: UserStatusType, expi
     });
 
     if (!session) {
-        redirect("/sign-in");
+        redirect("/login");
     }
 
     // Get role of current user and validate

--- a/src/actions/user-actions.ts
+++ b/src/actions/user-actions.ts
@@ -3,6 +3,7 @@
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import { $Enums } from "@prisma/client";
 import UserRole = $Enums.UserRole;
 import UserStatusType = $Enums.UserStatusType;
@@ -13,6 +14,27 @@ import { prisma } from "@/lib/prisma";
  * Returns the role of the session's user
  * @return {Promise<$Enums.UserRole>}
  */
+export async function updateAllowMatureListingContentPreference(
+    allowMatureListingContent: boolean
+): Promise<{ success: boolean }> {
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    });
+
+    if (!session?.user) {
+        redirect("/sign-in");
+    }
+
+    await prisma.user.update({
+        where: { id: session.user.id },
+        data: { allowMatureListingContent },
+    });
+
+    revalidatePath("/profile");
+    revalidatePath("/market");
+    return { success: true };
+}
+
 export async function getCurrentUserRole(): Promise<$Enums.UserRole> {
     // Validate session
     const session = await auth.api.getSession({

--- a/src/app/admin/profanity/page.tsx
+++ b/src/app/admin/profanity/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getCurrentUserRole } from "@/actions/user-actions";
+import AdminProfanityTerms from "@/components/admin/admin-profanity-terms";
+
+export default async function AdminProfanityPage() {
+    const userRole = await getCurrentUserRole();
+    if (userRole !== "ADMIN") {
+        redirect("/market");
+    }
+
+    return (
+        <main className="px-8 py-8 lg:px-20 lg:py-12 max-w-5xl mx-auto">
+            <div className="flex flex-wrap items-start justify-between gap-4 mb-8">
+                <div>
+                    <Link href="/admin" className="text-green text-sm font-semibold hover:underline mb-2 inline-block">
+                        ← Admin dashboard
+                    </Link>
+                    <h1 className="text-4xl font-bold">Profanity lists</h1>
+                    <p className="text-gray-600 mt-2">Manage whitelist and blacklist terms for listings, messages, and reports.</p>
+                </div>
+                <Link
+                    href="/admin/users"
+                    className="px-4 py-2 rounded-lg border border-gray-300 text-sm font-semibold text-gray-800 hover:bg-gray-50"
+                >
+                    Users & queues
+                </Link>
+            </div>
+
+            <AdminProfanityTerms userRole={userRole} />
+        </main>
+    );
+}

--- a/src/app/market/create-listing/page.tsx
+++ b/src/app/market/create-listing/page.tsx
@@ -14,6 +14,7 @@ import Button from "@/components/ui/Button";
 import { useSearchParams } from "next/navigation";
 import { toastService } from "@/lib/toast-service";
 import { getCategories, getCategoriesCount } from "@/actions/category-actions";
+import { previewListingProfanityForForm } from "@/actions/listing-profanity-preview";
 
 type EditableListingStatus = "AVAILABLE" | "DRAFT";
 type ListingCategory = { id: number; name: string };
@@ -57,6 +58,13 @@ export default function CreateListing() {
     const [isLoadingCategories, setIsLoadingCategories] = useState(true);
     const [userRole, setUserRole] = useState<string | null>(null);
     const lastToastMessageRef = useRef<string | null>(null);
+    const profanityPreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const [profanityPreview, setProfanityPreview] = useState<{
+        titleMatches: string[];
+        descriptionMatches: string[];
+        willHoldForReview: boolean;
+    } | null>(null);
+    const [profanityPreviewLoading, setProfanityPreviewLoading] = useState(false);
 
     const canSetProfessorOnly = userRole === "FACULTY" || userRole === "ADMIN";
 
@@ -148,6 +156,38 @@ export default function CreateListing() {
     }, [canSetProfessorOnly]);
 
     useEffect(() => {
+        if (profanityPreviewTimerRef.current) {
+            clearTimeout(profanityPreviewTimerRef.current);
+        }
+        const combined = `${title}\n${description}`.trim();
+        if (!combined) {
+            setProfanityPreview(null);
+            setProfanityPreviewLoading(false);
+            return;
+        }
+
+        setProfanityPreviewLoading(true);
+        profanityPreviewTimerRef.current = setTimeout(() => {
+            void (async () => {
+                try {
+                    const result = await previewListingProfanityForForm(title, description);
+                    setProfanityPreview(result);
+                } catch {
+                    setProfanityPreview(null);
+                } finally {
+                    setProfanityPreviewLoading(false);
+                }
+            })();
+        }, 450);
+
+        return () => {
+            if (profanityPreviewTimerRef.current) {
+                clearTimeout(profanityPreviewTimerRef.current);
+            }
+        };
+    }, [title, description]);
+
+    useEffect(() => {
         const message = state.message?.content;
         if (!message) return;
 
@@ -202,6 +242,52 @@ export default function CreateListing() {
                         validationErrors={state.validationErrors}
                         required
                     />
+
+                    {(title.trim() || description.trim()) && (
+                        <div
+                            className="rounded-lg border px-4 py-3 text-sm"
+                            role="status"
+                            aria-live="polite"
+                            style={{
+                                borderColor: profanityPreview?.willHoldForReview ? "#f59e0b" : "#d1d5db",
+                                backgroundColor: profanityPreview?.willHoldForReview ? "#fffbeb" : "#f9fafb",
+                            }}
+                        >
+                            {profanityPreviewLoading ? (
+                                <p className="text-gray-600">Checking profanity filter…</p>
+                            ) : profanityPreview?.willHoldForReview ? (
+                                <>
+                                    <p className="font-semibold text-amber-900 mb-2">
+                                        This may be held for review because the following may be censored or flagged:
+                                    </p>
+                                    {profanityPreview.titleMatches.length > 0 && (
+                                        <p className="text-gray-800 mb-1">
+                                            <span className="font-medium">Title:</span>{" "}
+                                            {profanityPreview.titleMatches.join(", ")}
+                                        </p>
+                                    )}
+                                    {profanityPreview.descriptionMatches.length > 0 && (
+                                        <p className="text-gray-800">
+                                            <span className="font-medium">Description:</span>{" "}
+                                            {profanityPreview.descriptionMatches.join(", ")}
+                                        </p>
+                                    )}
+                                    {profanityPreview.titleMatches.length === 0 &&
+                                        profanityPreview.descriptionMatches.length === 0 && (
+                                            <p className="text-gray-800">
+                                                Matched the profanity rules (see admin whitelist if this is a false
+                                                positive).
+                                            </p>
+                                        )}
+                                </>
+                            ) : (
+                                <p className="text-gray-600">
+                                    No profanity filter matches in the title or description right now (admin whitelist
+                                    may apply).
+                                </p>
+                            )}
+                        </div>
+                    )}
 
                     {/* Price */}
                     <PriceInput

--- a/src/app/market/listing/[id]/page.tsx
+++ b/src/app/market/listing/[id]/page.tsx
@@ -7,47 +7,77 @@ import ImageCarousel from "@/components/ui/ImageCarousel";
 import { Suspense } from "react";
 import ListingSuccessToast from "@/components/ui/ListingSuccessToast";
 import { prisma } from "@/lib/prisma";
+import { MessageProfanityFlagStatus } from "@prisma/client";
 
 export default async function ListingDetail({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
     const session = await auth.api.getSession({
         headers: await headers()
     });
-    const listing = await prisma.listing.findUnique({
-        where: {
-            id: id
-        },
-        include: {
-            owner: {
-                select: {
-                    name: true,
-                    email: true,
-                }
+    const [listing, viewerPrefs] = await Promise.all([
+        prisma.listing.findUnique({
+            where: {
+                id: id
             },
-            categories: {
-                select: {
-                    id: true,
-                    name: true,
-                }
-            },
-            images: {
-                select: {
-                    id: true,
-                    url: true,
-                    sortOrder: true,
+            include: {
+                owner: {
+                    select: {
+                        name: true,
+                        email: true,
+                    }
                 },
-                orderBy: {
-                    sortOrder: 'asc',
-                }
+                categories: {
+                    select: {
+                        id: true,
+                        name: true,
+                    }
+                },
+                images: {
+                    select: {
+                        id: true,
+                        url: true,
+                        sortOrder: true,
+                    },
+                    orderBy: {
+                        sortOrder: 'asc',
+                    }
+                },
+                listingProfanityFlags: {
+                    where: { status: MessageProfanityFlagStatus.REVIEWED_NO_ACTION },
+                    orderBy: [{ reviewedAt: "desc" }, { createdAt: "desc" }],
+                    select: {
+                        originalTitle: true,
+                        originalDescription: true,
+                    },
+                    take: 1,
+                },
             }
-        }
-    });
+        }),
+        session?.user?.id
+            ? prisma.user.findUnique({
+                where: { id: session.user.id },
+                select: { allowMatureListingContent: true },
+            })
+            : Promise.resolve(null),
+    ]);
 
     if (!listing) {
         notFound();
     }
 
     const isOwner = session?.user?.id === listing.ownerId;
+    const releasedProfanityRow = listing.listingProfanityFlags[0];
+    const allowMature = viewerPrefs?.allowMatureListingContent ?? false;
+    const displayTitle =
+        releasedProfanityRow && allowMature
+            ? releasedProfanityRow.originalTitle
+            : listing.title;
+    const displayDescription =
+        releasedProfanityRow && allowMature
+            ? releasedProfanityRow.originalDescription
+            : listing.description;
+    const blurListingImages = Boolean(releasedProfanityRow) && !allowMature;
+
     const postedDate = new Intl.DateTimeFormat("en-US", {
         month: "short",
         day: "numeric",
@@ -67,7 +97,7 @@ export default async function ListingDetail({ params }: { params: Promise<{ id: 
                 <div className="bg-white rounded-lg shadow-lg p-8">
                     <div className="flex justify-between items-start mb-4">
                         <div>
-                            <h1 className="text-4xl font-bold">{listing.title}</h1>
+                            <h1 className="text-4xl font-bold">{displayTitle}</h1>
                             <p className="text-sm text-gray-500 mt-2">Posted {postedDate}</p>
                         </div>
                         {isOwner && (
@@ -89,7 +119,21 @@ export default async function ListingDetail({ params }: { params: Promise<{ id: 
                     </div>
                     
                     {/* Image Carousel */}
-                    <ImageCarousel images={listing.images} alt={listing.title} />
+                    <ImageCarousel
+                        images={listing.images}
+                        alt={displayTitle}
+                        blurImages={blurListingImages}
+                    />
+                    {blurListingImages ? (
+                        <p className="text-sm text-gray-500 mb-6 -mt-2">
+                            This listing matched the profanity filter and was cleared by a moderator; the public
+                            listing stays censored unless you enable the 18+ option in{" "}
+                            <Link href="/profile" className="text-green underline hover:no-underline">
+                                Account → Profile Settings
+                            </Link>
+                            .
+                        </p>
+                    ) : null}
 
                     <div className="flex items-center justify-between mb-6 pb-6 border-b">
                         <span className="text-4xl font-bold text-green">${listing.price.toString()}</span>
@@ -102,7 +146,7 @@ export default async function ListingDetail({ params }: { params: Promise<{ id: 
 
                     <div className="mb-6">
                         <h2 className="text-xl font-semibold mb-2">Description</h2>
-                        <p className="text-gray-700 whitespace-pre-wrap">{listing.description}</p>
+                        <p className="text-gray-700 whitespace-pre-wrap">{displayDescription}</p>
                     </div>
 
                 {listing.categories.length > 0 && (

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -21,8 +21,8 @@ export default async function MarketPage({
         mine: isMyListingsView,
     };
 
-    const listingsResponse = getListings("", initialFilters, 0, 12);
-    const userRole = getCurrentUserRole();
+    const listingsResponse = await getListings("", initialFilters, 0, 12);
+    const userRole = await getCurrentUserRole();
     const session = await auth.api.getSession({
         headers: await headers(),
     });

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { ProfileTabs } from "@/components/ProfileTabs";
+import { prisma } from "@/lib/prisma";
 
 export default async function ProfilePage() {
   const session = await auth.api.getSession({ headers: await headers() });
@@ -14,6 +15,11 @@ export default async function ProfilePage() {
 
   const { name = "", email = "", image = null } = session.user;
 
+  const prefs = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { allowMatureListingContent: true },
+  });
+
   return (
     <main className="min-h-screen px-8 py-4 lg:px-20 lg:py-12">
       <div className="w-full max-w-4xl mx-auto">
@@ -23,7 +29,12 @@ export default async function ProfilePage() {
 
         <div className="bg-white rounded-lg shadow-lg p-8">
           <h1 className="text-4xl font-bold mb-6">My Profile</h1>
-          <ProfileTabs initialName={name} initialEmail={email} initialImage={image} />
+          <ProfileTabs
+            initialName={name}
+            initialEmail={email}
+            initialImage={image}
+            initialAllowMatureListingContent={prefs?.allowMatureListingContent ?? false}
+          />
         </div>
       </div>
     </main>

--- a/src/components/ProfileTabs.tsx
+++ b/src/components/ProfileTabs.tsx
@@ -8,9 +8,15 @@ interface ProfileTabsProps {
   initialName: string;
   initialEmail: string;
   initialImage: string | null;
+  initialAllowMatureListingContent: boolean;
 }
 
-export function ProfileTabs({ initialName, initialEmail, initialImage }: ProfileTabsProps) {
+export function ProfileTabs({
+  initialName,
+  initialEmail,
+  initialImage,
+  initialAllowMatureListingContent,
+}: ProfileTabsProps) {
   const [activeTab, setActiveTab] = useState<"profile" | "searches">("profile");
 
   return (
@@ -42,7 +48,12 @@ export function ProfileTabs({ initialName, initialEmail, initialImage }: Profile
       {/* Tab Content */}
       <div className="mt-6">
         {activeTab === "profile" && (
-          <ProfileEditor initialName={initialName} initialEmail={initialEmail} initialImage={initialImage} />
+          <ProfileEditor
+            initialName={initialName}
+            initialEmail={initialEmail}
+            initialImage={initialImage}
+            initialAllowMatureListingContent={initialAllowMatureListingContent}
+          />
         )}
         {activeTab === "searches" && <SavedQueriesManager />}
       </div>

--- a/src/components/admin/admin-dashboard.tsx
+++ b/src/components/admin/admin-dashboard.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { getAdminStats, getFirstListingsAwaitingApproval, getSuspendedUsers } from "@/actions/admin-actions";
+import { getAdminStats, getPendingListingApprovals, getSuspendedUsers } from "@/actions/admin-actions";
 
 export default function Admin({ userRole }: { userRole: string | null }) {
     const [stats, setStats] = useState({
@@ -26,7 +26,7 @@ export default function Admin({ userRole }: { userRole: string | null }) {
             try {
                 const [statsData, pendingData, suspendedData] = await Promise.all([
                     getAdminStats(),
-                    getFirstListingsAwaitingApproval(),
+                    getPendingListingApprovals(200, 0, "oldest"),
                     getSuspendedUsers(),
                 ]);
 
@@ -77,7 +77,7 @@ export default function Admin({ userRole }: { userRole: string | null }) {
                 <div className="bg-white border-2 border-gray-200 rounded-2xl p-6">
                     <div className="text-gray-500 text-sm font-semibold mb-2">Pending Approvals</div>
                     <div className="text-3xl font-black text-orange-500">{loading ? "-" : stats.pendingCount}</div>
-                    <div className="text-xs text-gray-400 mt-1">First listings to review</div>
+                    <div className="text-xs text-gray-400 mt-1">Pending due to first listing and/or profanity</div>
                 </div>
                 <div className="bg-white border-2 border-gray-200 rounded-2xl p-6">
                     <div className="text-gray-500 text-sm font-semibold mb-2">Pending Reports</div>
@@ -93,7 +93,7 @@ export default function Admin({ userRole }: { userRole: string | null }) {
 
             <div>
                 <h2 className="text-2xl font-bold mb-4">Quick Actions</h2>
-                <div className="grid grid-cols-4 gap-6">
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
                     <Link href="/admin/users" className="bg-orange-500 rounded-3xl h-[200px] flex items-center justify-center text-white hover:shadow-xl transition-shadow">
                         <div className="text-center">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="size-12 mx-auto mb-3">
@@ -127,6 +127,15 @@ export default function Admin({ userRole }: { userRole: string | null }) {
                                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
                             </svg>
                             <div className="text-xl font-bold">Handle Reports</div>
+                        </div>
+                    </Link>
+
+                    <Link href="/admin/profanity" className="bg-amber-700 rounded-3xl h-[200px] flex items-center justify-center text-white hover:shadow-xl transition-shadow">
+                        <div className="text-center px-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="size-12 mx-auto mb-3">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664M5.25 12v3.75m0-3.75h3.75m-3.75 0H9m-3.75 0H5.25m0 0v-.75A2.25 2.25 0 017.5 9h9a2.25 2.25 0 012.25 2.25v.75m-13.5 0H3.75m0 0h-.75a.75.75 0 01-.75-.75V15m14.25 0h.75a.75.75 0 00.75-.75v-3m-18 0V9.75m18 0v.75a.75.75 0 01-.75.75H3.75a.75.75 0 01-.75-.75V9.75" />
+                            </svg>
+                            <div className="text-xl font-bold">Profanity lists</div>
                         </div>
                     </Link>
                 </div>

--- a/src/components/admin/admin-listings.tsx
+++ b/src/components/admin/admin-listings.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { RecentListing, PendingListing } from "@/types/admin/listings";
-import { getAdminStats, getRecentlyListedItems, getFirstListingsAwaitingApproval, approveFirstListing, rejectFirstListing, deleteListing } from "@/actions/admin-actions";
+import { getAdminStats, getRecentlyListedItems, getPendingListingApprovals, approveFirstListing, rejectFirstListing, deleteListing, type PendingApprovalSort } from "@/actions/admin-actions";
 import Pagination from "@/components/ui/Pagination";
 
 export default function AdminListings({ userRole }: { userRole: string | null }) {
@@ -21,6 +21,7 @@ export default function AdminListings({ userRole }: { userRole: string | null })
 
     const [listingsPage, setListingsPage] = useState(1);
     const [pendingListingsPage, setPendingListingsPage] = useState(1);
+    const [pendingApprovalsSort, setPendingApprovalsSort] = useState<PendingApprovalSort>("oldest");
 
     const [totalListingsCount, setTotalListingsCount] = useState(0);
     const [totalPendingListingsCount, setTotalPendingListingsCount] = useState(0);
@@ -36,7 +37,11 @@ export default function AdminListings({ userRole }: { userRole: string | null })
                 const [statsData, recentData, pendingData] = await Promise.all([
                     getAdminStats(),
                     getRecentlyListedItems(LISTINGS_PER_PAGE + 1, (listingsPage - 1) * LISTINGS_PER_PAGE),
-                    getFirstListingsAwaitingApproval(PENDING_PER_PAGE + 1, (pendingListingsPage - 1) * PENDING_PER_PAGE),
+                    getPendingListingApprovals(
+                        PENDING_PER_PAGE + 1,
+                        (pendingListingsPage - 1) * PENDING_PER_PAGE,
+                        pendingApprovalsSort
+                    ),
                 ]);
 
                 setRecentListings(recentData.slice(0, LISTINGS_PER_PAGE));
@@ -56,7 +61,7 @@ export default function AdminListings({ userRole }: { userRole: string | null })
         };
 
         load();
-    }, [userRole, router, listingsPage, pendingListingsPage]);
+    }, [userRole, router, listingsPage, pendingListingsPage, pendingApprovalsSort]);
 
     function handleViewListing(listingId: string) {
         router.push(`/market/listing/${listingId}`);
@@ -209,15 +214,33 @@ export default function AdminListings({ userRole }: { userRole: string | null })
                 </div>
             </div>
 
-            {/* First Listings Awaiting Approval */}
+            {/* Pending Listing Approvals */}
             <div>
-                <h2 className="text-2xl font-bold mb-4">First Listings Awaiting Approval</h2>
+                <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold">Pending Listing Approvals</h2>
+                    <div className="flex items-center gap-2">
+                        <label htmlFor="pendingSort" className="text-sm text-gray-600">Sort</label>
+                        <select
+                            id="pendingSort"
+                            value={pendingApprovalsSort}
+                            onChange={(e) => {
+                                setPendingApprovalsSort(e.target.value as PendingApprovalSort);
+                                setPendingListingsPage(1);
+                            }}
+                            className="border border-gray-300 rounded-lg px-3 py-2 text-sm"
+                        >
+                            <option value="oldest">Oldest pending first</option>
+                            <option value="newest">Most recent pending first</option>
+                        </select>
+                    </div>
+                </div>
                 <div className="bg-white border-2 border-gray-200 rounded-2xl p-6">
-                    <div className="grid grid-cols-6 font-semibold text-gray-700 mb-3">
+                    <div className="grid grid-cols-7 font-semibold text-gray-700 mb-3">
                         <div>Listing Title</div>
                         <div>Seller</div>
                         <div>Category</div>
                         <div>Price</div>
+                        <div>Pending Reason</div>
                         <div>Date Submitted</div>
                         <div>Action</div>
                     </div>
@@ -228,7 +251,7 @@ export default function AdminListings({ userRole }: { userRole: string | null })
                         <div className="text-gray-500 text-center py-8">No pending listings</div>
                     ) : (
                         pendingListings.map((listing) => (
-                            <div key={listing.id} className="grid grid-cols-6 py-3 items-center hover:bg-green-50 rounded-xl px-2 transition">
+                            <div key={listing.id} className="grid grid-cols-7 py-3 items-center hover:bg-green-50 rounded-xl px-2 transition">
                                 <div className="truncate" title={listing.title}>
                                     {listing.title}
                                 </div>
@@ -237,6 +260,15 @@ export default function AdminListings({ userRole }: { userRole: string | null })
                                 </div>
                                 <div>{listing.category}</div>
                                 <div>{listing.price}</div>
+                                <div>
+                                    <span className="px-2 py-1 rounded-full text-xs font-semibold bg-amber-100 text-amber-800">
+                                        {listing.pendingReason === "BOTH"
+                                            ? "First listing + profanity"
+                                            : listing.pendingReason === "PROFANITY"
+                                                ? "Profanity match"
+                                                : "First listing"}
+                                    </span>
+                                </div>
                                 <div>{listing.date}</div>
                                 <div className="flex gap-2">
                                     <button

--- a/src/components/admin/admin-profanity-terms.tsx
+++ b/src/components/admin/admin-profanity-terms.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ProfanityListType } from "@prisma/client";
+import {
+    addProfanityModerationTerm,
+    deleteProfanityModerationTerm,
+    getProfanityModerationTerms,
+    type ProfanityModerationTermRow,
+} from "@/actions/admin-actions";
+
+export default function AdminProfanityTerms({ userRole }: { userRole: string | null }) {
+    const router = useRouter();
+    const [loading, setLoading] = useState(true);
+    const [terms, setTerms] = useState<ProfanityModerationTermRow[]>([]);
+    const [whitelistInput, setWhitelistInput] = useState("");
+    const [blacklistInput, setBlacklistInput] = useState("");
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function load() {
+        setLoading(true);
+        setError(null);
+        try {
+            const data = await getProfanityModerationTerms();
+            setTerms(data);
+        } catch (e) {
+            console.error(e);
+            setError("Could not load terms.");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        if (userRole !== "ADMIN") {
+            router.push("/market");
+            return;
+        }
+        void load();
+    }, [userRole, router]);
+
+    async function handleAdd(listType: ProfanityListType, raw: string) {
+        const trimmed = raw.trim();
+        if (!trimmed) return;
+        setSaving(true);
+        setError(null);
+        const res = await addProfanityModerationTerm(listType, trimmed);
+        setSaving(false);
+        if (!res.success) {
+            setError(res.error ?? "Could not add term.");
+            return;
+        }
+        if (listType === ProfanityListType.WHITELIST) setWhitelistInput("");
+        else setBlacklistInput("");
+        await load();
+    }
+
+    async function handleDelete(id: string) {
+        if (!confirm("Remove this term from the list?")) return;
+        setSaving(true);
+        setError(null);
+        await deleteProfanityModerationTerm(id);
+        setSaving(false);
+        await load();
+    }
+
+    const whitelist = terms.filter((t) => t.listType === ProfanityListType.WHITELIST);
+    const blacklist = terms.filter((t) => t.listType === ProfanityListType.BLACKLIST);
+
+    return (
+        <div className="flex flex-col gap-8">
+            <p className="text-gray-600 text-sm max-w-3xl">
+                <strong>Whitelist</strong> terms are never censored and do not trigger listing review.{" "}
+                <strong>Blacklist</strong> terms are censored like built-in profanity and can trigger review. Terms are
+                stored lowercase; multi-word phrases use the same word-boundary rules as the built-in list.
+            </p>
+
+            {error ? (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-800">{error}</div>
+            ) : null}
+
+            {loading ? (
+                <div className="text-gray-500">Loading…</div>
+            ) : (
+                <div className="grid md:grid-cols-2 gap-8">
+                    <div className="border border-gray-200 rounded-xl p-5 bg-white">
+                        <h3 className="text-lg font-bold text-gray-900 mb-2">Whitelist</h3>
+                        <p className="text-xs text-gray-500 mb-3">Allowed words or phrases (e.g. place names, course jargon).</p>
+                        <div className="flex gap-2 mb-4">
+                            <input
+                                type="text"
+                                value={whitelistInput}
+                                onChange={(e) => setWhitelistInput(e.target.value)}
+                                placeholder="e.g. scunthorpe"
+                                className="flex-1 border rounded-lg px-3 py-2 text-sm"
+                                disabled={saving}
+                            />
+                            <button
+                                type="button"
+                                disabled={saving}
+                                onClick={() => void handleAdd(ProfanityListType.WHITELIST, whitelistInput)}
+                                className="px-4 py-2 rounded-lg bg-green text-white text-sm font-semibold hover:opacity-90 disabled:opacity-50"
+                            >
+                                Add
+                            </button>
+                        </div>
+                        <ul className="space-y-2 max-h-72 overflow-y-auto text-sm">
+                            {whitelist.length === 0 ? (
+                                <li className="text-gray-400">No whitelist entries.</li>
+                            ) : (
+                                whitelist.map((t) => (
+                                    <li
+                                        key={t.id}
+                                        className="flex justify-between items-center gap-2 rounded-lg bg-gray-50 px-3 py-2"
+                                    >
+                                        <span className="font-mono break-all">{t.term}</span>
+                                        <button
+                                            type="button"
+                                            disabled={saving}
+                                            onClick={() => void handleDelete(t.id)}
+                                            className="shrink-0 text-red-600 text-xs font-semibold hover:underline"
+                                        >
+                                            Remove
+                                        </button>
+                                    </li>
+                                ))
+                            )}
+                        </ul>
+                    </div>
+
+                    <div className="border border-gray-200 rounded-xl p-5 bg-white">
+                        <h3 className="text-lg font-bold text-gray-900 mb-2">Blacklist</h3>
+                        <p className="text-xs text-gray-500 mb-3">Extra words or phrases to censor and flag for review.</p>
+                        <div className="flex gap-2 mb-4">
+                            <input
+                                type="text"
+                                value={blacklistInput}
+                                onChange={(e) => setBlacklistInput(e.target.value)}
+                                placeholder="word or multi word phrase"
+                                className="flex-1 border rounded-lg px-3 py-2 text-sm"
+                                disabled={saving}
+                            />
+                            <button
+                                type="button"
+                                disabled={saving}
+                                onClick={() => void handleAdd(ProfanityListType.BLACKLIST, blacklistInput)}
+                                className="px-4 py-2 rounded-lg bg-gray-800 text-white text-sm font-semibold hover:bg-gray-900 disabled:opacity-50"
+                            >
+                                Add
+                            </button>
+                        </div>
+                        <ul className="space-y-2 max-h-72 overflow-y-auto text-sm">
+                            {blacklist.length === 0 ? (
+                                <li className="text-gray-400">No blacklist entries.</li>
+                            ) : (
+                                blacklist.map((t) => (
+                                    <li
+                                        key={t.id}
+                                        className="flex justify-between items-center gap-2 rounded-lg bg-amber-50 px-3 py-2"
+                                    >
+                                        <span className="font-mono break-all">{t.term}</span>
+                                        <button
+                                            type="button"
+                                            disabled={saving}
+                                            onClick={() => void handleDelete(t.id)}
+                                            className="shrink-0 text-red-600 text-xs font-semibold hover:underline"
+                                        >
+                                            Remove
+                                        </button>
+                                    </li>
+                                ))
+                            )}
+                        </ul>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/admin/admin-users.tsx
+++ b/src/components/admin/admin-users.tsx
@@ -11,6 +11,7 @@ import {
     getPendingProfanityFlags,
     reviewProfanityFlag,
     getPendingListingProfanityFlags,
+    type ListingProfanityQueueSort,
     reviewListingProfanityFlag,
     type ProfanityFlagRow,
     type ListingProfanityFlagRow,
@@ -60,6 +61,7 @@ export default function AdminUsers({ userRole }: { userRole: string | null }) {
     const [listingProfanityPage, setListingProfanityPage] = useState(1);
     const [listingProfanityTotalCount, setListingProfanityTotalCount] = useState(0);
     const [listingProfanityFlagIdForAction, setListingProfanityFlagIdForAction] = useState<string | null>(null);
+    const [listingProfanitySort, setListingProfanitySort] = useState<ListingProfanityQueueSort>("newest");
     const [queueStats, setQueueStats] = useState({
         pendingProfanityFlags: 0,
         pendingListingProfanityFlags: 0,
@@ -86,7 +88,8 @@ export default function AdminUsers({ userRole }: { userRole: string | null }) {
                     getPendingProfanityFlags(PROFANITY_PER_PAGE, (profanityPage - 1) * PROFANITY_PER_PAGE),
                     getPendingListingProfanityFlags(
                         LISTING_PROFANITY_PER_PAGE,
-                        (listingProfanityPage - 1) * LISTING_PROFANITY_PER_PAGE
+                        (listingProfanityPage - 1) * LISTING_PROFANITY_PER_PAGE,
+                        listingProfanitySort
                     ),
                 ]);
 
@@ -116,7 +119,11 @@ export default function AdminUsers({ userRole }: { userRole: string | null }) {
         };
 
         load();
-    }, [userRole, router, usersPage, suspendedUsersPage, profanityPage, listingProfanityPage]);
+    }, [userRole, router, usersPage, suspendedUsersPage, profanityPage, listingProfanityPage, listingProfanitySort]);
+
+    useEffect(() => {
+        setListingProfanityPage(1);
+    }, [listingProfanitySort]);
 
     function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
         if (selectedUser) {
@@ -179,7 +186,8 @@ export default function AdminUsers({ userRole }: { userRole: string | null }) {
                 getPendingProfanityFlags(PROFANITY_PER_PAGE, (profanityPage - 1) * PROFANITY_PER_PAGE),
                 getPendingListingProfanityFlags(
                     LISTING_PROFANITY_PER_PAGE,
-                    (listingProfanityPage - 1) * LISTING_PROFANITY_PER_PAGE
+                    (listingProfanityPage - 1) * LISTING_PROFANITY_PER_PAGE,
+                    listingProfanitySort
                 ),
             ]);
             setQueueStats({
@@ -230,7 +238,8 @@ export default function AdminUsers({ userRole }: { userRole: string | null }) {
                 getPendingProfanityFlags(PROFANITY_PER_PAGE, (profanityPage - 1) * PROFANITY_PER_PAGE),
                 getPendingListingProfanityFlags(
                     LISTING_PROFANITY_PER_PAGE,
-                    (listingProfanityPage - 1) * LISTING_PROFANITY_PER_PAGE
+                    (listingProfanityPage - 1) * LISTING_PROFANITY_PER_PAGE,
+                    listingProfanitySort
                 ),
             ]);
             setQueueStats({
@@ -281,7 +290,8 @@ export default function AdminUsers({ userRole }: { userRole: string | null }) {
                 getAdminStats(),
                 getPendingListingProfanityFlags(
                     LISTING_PROFANITY_PER_PAGE,
-                    (listingProfanityPage - 1) * LISTING_PROFANITY_PER_PAGE
+                    (listingProfanityPage - 1) * LISTING_PROFANITY_PER_PAGE,
+                    listingProfanitySort
                 ),
             ]);
             setQueueStats({
@@ -480,9 +490,30 @@ export default function AdminUsers({ userRole }: { userRole: string | null }) {
             <div>
                 <h2 className="text-2xl font-bold mb-4">Listing moderation (profanity)</h2>
                 <p className="text-gray-600 text-sm mb-4 max-w-3xl">
-                    When a listing title or description matches the profanity filter, the public listing shows censored text;
-                    originals appear here for review. Dismiss if acceptable, or suspend or ban the seller if needed.
+                    When a listing matches the profanity filter, censored text is stored on the listing; originals stay
+                    on this flag for review. Dismiss when acceptable so the listing can publish; users who opt in under
+                    Profile (18+) see originals and unblurred images. Suspend or ban the seller if needed.
                 </p>
+                <div className="flex flex-wrap items-center gap-3 mb-4">
+                    <label htmlFor="listingProfanitySort" className="text-sm font-semibold text-gray-700">
+                        Sort by flag date
+                    </label>
+                    <select
+                        id="listingProfanitySort"
+                        value={listingProfanitySort}
+                        onChange={(e) => setListingProfanitySort(e.target.value as ListingProfanityQueueSort)}
+                        className="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white"
+                    >
+                        <option value="newest">Newest first</option>
+                        <option value="oldest">Oldest first</option>
+                    </select>
+                    <Link
+                        href="/admin/profanity"
+                        className="text-sm text-green font-semibold hover:underline ml-auto"
+                    >
+                        Whitelist / blacklist terms →
+                    </Link>
+                </div>
                 <div className="bg-white border-2 border-gray-200 rounded-2xl p-6">
                     {loading ? (
                         <div className="text-gray-500 text-center py-8">Loading...</div>

--- a/src/components/features/MarketSection.tsx
+++ b/src/components/features/MarketSection.tsx
@@ -21,13 +21,13 @@ export default function MarketSection({
     currentUserId,
     initialFilters,
 }: {
-    listingsResponse: Promise<ListingObject[]>;
-    userRoleResponse: Promise<UserRole>;
+    listingsResponse: ListingObject[];
+    userRoleResponse: UserRole;
     currentUserId: string;
     initialFilters?: ListingFilters;
 }) {
-    const [listings, setListings] = useState(use(listingsResponse)); // Listing object
-    const userRole = use(userRoleResponse);
+    const [listings, setListings] = useState(listingsResponse); // Listing object
+    const userRole = userRoleResponse;
     const [searchQuery, setSearchQuery] = useState(""); // Search input state
     const [listingsLoading, setListingsLoading] = useState(false); // Listing loading state
     const [newPageLoading, setNewPageLoading] = useState(false);

--- a/src/components/profile/ProfileEditor.tsx
+++ b/src/components/profile/ProfileEditor.tsx
@@ -3,16 +3,27 @@
 import React, { useState } from "react";
 import Button from "@/components/ui/Button";
 import { toastService } from "@/lib/toast-service";
+import { updateAllowMatureListingContentPreference } from "@/actions/user-actions";
 
 interface Props {
   initialName?: string | null;
   initialEmail?: string | null;
   initialImage?: string | null;
+  initialAllowMatureListingContent: boolean;
 }
 
-export default function ProfileEditor({ initialName, initialEmail, initialImage }: Props) {
+export default function ProfileEditor({
+  initialName,
+  initialEmail,
+  initialImage,
+  initialAllowMatureListingContent,
+}: Props) {
   const [name, setName] = useState(initialName ?? "");
   const [image, setImage] = useState(initialImage ?? "");
+  const [allowMatureListingContent, setAllowMatureListingContent] = useState(
+    initialAllowMatureListingContent
+  );
+  const [maturePrefSaving, setMaturePrefSaving] = useState(false);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -68,6 +79,20 @@ export default function ProfileEditor({ initialName, initialEmail, initialImage 
     }
   };
 
+  async function onMatureContentToggle(checked: boolean) {
+    setMaturePrefSaving(true);
+    try {
+      await updateAllowMatureListingContentPreference(checked);
+      setAllowMatureListingContent(checked);
+      toastService.toast("Preference saved", "success");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toastService.toast(msg || "Could not save preference", "error");
+    } finally {
+      setMaturePrefSaving(false);
+    }
+  }
+
   return (
     <form onSubmit={submit} className="space-y-4">
       <div className="flex items-center gap-6">
@@ -110,6 +135,28 @@ export default function ProfileEditor({ initialName, initialEmail, initialImage 
             <div className="text-sm text-gray-500">{uploading ? "Uploading..." : uploadError}</div>
           </div>
         </div>
+      </div>
+
+      <div className="border-t pt-6 mt-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">Mature content (18+)</h2>
+        <p className="text-sm text-gray-600 mb-3 max-w-xl">
+          Some listings stay word-censored in the catalog until you opt in here. When enabled, you will see original
+          titles, descriptions, and unblurred photos for listings that matched the profanity filter and were then
+          cleared by a moderator.
+        </p>
+        <label className="flex items-start gap-3 cursor-pointer select-none max-w-xl">
+          <input
+            type="checkbox"
+            className="mt-1 h-4 w-4 rounded border-gray-300"
+            checked={allowMatureListingContent}
+            disabled={maturePrefSaving}
+            onChange={(e) => void onMatureContentToggle(e.target.checked)}
+          />
+          <span className="text-sm text-gray-800">
+            I am 18 or older and want to see those listings uncensored
+            {maturePrefSaving ? <span className="text-gray-500"> (saving…)</span> : null}
+          </span>
+        </label>
       </div>
 
       <div className="flex gap-2 items-center">

--- a/src/components/ui/ImageCarousel.tsx
+++ b/src/components/ui/ImageCarousel.tsx
@@ -6,9 +6,11 @@ import Image from "next/image";
 interface ImageCarouselProps {
     images: { id: number; url: string; sortOrder: number }[];
     alt: string;
+    /** Strong blur on images (e.g. listings cleared by moderators after a profanity match). */
+    blurImages?: boolean;
 }
 
-export default function ImageCarousel({ images, alt }: ImageCarouselProps) {
+export default function ImageCarousel({ images, alt, blurImages = false }: ImageCarouselProps) {
     const [currentIndex, setCurrentIndex] = useState(0);
 
     if (images.length === 0) {
@@ -35,7 +37,11 @@ export default function ImageCarousel({ images, alt }: ImageCarouselProps) {
                     src={images[currentIndex].url}
                     alt={`${alt} - Image ${currentIndex + 1}`}
                     fill
-                    className="object-contain"
+                    className={
+                        blurImages
+                            ? "object-contain blur-2xl scale-105 select-none"
+                            : "object-contain"
+                    }
                     priority
                     unoptimized
                 />
@@ -87,7 +93,11 @@ export default function ImageCarousel({ images, alt }: ImageCarouselProps) {
                                 src={image.url}
                                 alt={`Thumbnail ${index + 1}`}
                                 fill
-                                className="object-cover"
+                                className={
+                                    blurImages
+                                        ? "object-cover blur-md scale-105 select-none"
+                                        : "object-cover"
+                                }
                                 unoptimized
                             />
                         </button>

--- a/src/components/ui/ListingCard.tsx
+++ b/src/components/ui/ListingCard.tsx
@@ -35,11 +35,13 @@ export default function ListingCard({
     const currentImage = hasValidImage ? sortedImages[currentImageIndex] : null;
     const isOwner = listing.ownerId === currentUserId;
     const editListingUrl = `/market/create-listing?edit=true&id=${listing.id}`;
+    const baseDisplayTitle = listing.matureAlternateTitle ?? listing.title;
     const listingTitle = listing.isDeniedByAdmin
-        ? `${listing.title} (DENIED)`
+        ? `${baseDisplayTitle} (DENIED)`
         : listing.listingStatus === "DRAFT" && listing.isPendingApproval
-            ? `${listing.title} (PENDING)`
-            : listing.title;
+            ? `${baseDisplayTitle} (PENDING)`
+            : baseDisplayTitle;
+    const blurCardImage = Boolean(listing.blurProfanityReleasedCardImage);
 
     const showCarouselControls = sortedImages.length > 1;
 
@@ -62,9 +64,13 @@ export default function ListingCard({
                     {hasValidImage ? (
                         <Image
                             src={currentImage!.url}
-                            alt={`${listing.title} image ${currentImageIndex + 1}`}
+                            alt={`${baseDisplayTitle} image ${currentImageIndex + 1}`}
                             fill
-                            className="object-cover group-hover:scale-105 transition-transform duration-500 ease-in-out"
+                            className={
+                                blurCardImage
+                                    ? "object-cover blur-xl scale-105 select-none group-hover:scale-105 transition-transform duration-500 ease-in-out"
+                                    : "object-cover group-hover:scale-105 transition-transform duration-500 ease-in-out"
+                            }
                             unoptimized
                         />
                     ) : (
@@ -77,7 +83,7 @@ export default function ListingCard({
                                 type="button"
                                 onClick={showPreviousImage}
                                 className="absolute left-2 top-1/2 -translate-y-1/2 z-20 bg-black/55 hover:bg-black/70 text-white p-2 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
-                                aria-label={`Previous image for ${listing.title}`}
+                                aria-label={`Previous image for ${baseDisplayTitle}`}
                             >
                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -87,7 +93,7 @@ export default function ListingCard({
                                 type="button"
                                 onClick={showNextImage}
                                 className="absolute right-2 top-1/2 -translate-y-1/2 z-20 bg-black/55 hover:bg-black/70 text-white p-2 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
-                                aria-label={`Next image for ${listing.title}`}
+                                aria-label={`Next image for ${baseDisplayTitle}`}
                             >
                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -119,7 +125,7 @@ export default function ListingCard({
 
             <Link
                 href={listingUrl}
-                aria-label={`Open ${listing.title}`}
+                aria-label={`Open ${baseDisplayTitle}`}
                 className="absolute inset-0 z-10"
             />
         </div>

--- a/src/components/ui/ListingSuccessToast.tsx
+++ b/src/components/ui/ListingSuccessToast.tsx
@@ -9,6 +9,7 @@ export default function ListingSuccessToast() {
     const searchParams = useSearchParams();
     const created = searchParams.get("created");
     const requiresApproval = searchParams.get("requiresApproval");
+    const pendingReason = searchParams.get("pendingReason");
     const updated = searchParams.get("updated");
     const deleted = searchParams.get("deleted");
     const hasShownRef = useRef(false);
@@ -17,7 +18,11 @@ export default function ListingSuccessToast() {
         if (hasShownRef.current) return;
 
         if (created === "true") {
-            if (requiresApproval === "true") {
+            if (pendingReason === "both") {
+                toastService.toast("Listing is pending admin review: your first listing plus profanity match requires approval.", "warn");
+            } else if (pendingReason === "profanity") {
+                toastService.toast("Listing was held for profanity review and is pending admin approval.", "warn");
+            } else if (requiresApproval === "true" || pendingReason === "first_listing") {
                 toastService.toast("Your first listing requires admin approval before it becomes available.", "info");
             } else {
                 toastService.toast("Listing created successfully!", "success");
@@ -36,7 +41,7 @@ export default function ListingSuccessToast() {
             toastService.toast("Listing deleted successfully!", "success");
             hasShownRef.current = true;
         }
-    }, [created, requiresApproval, updated, deleted]);
+    }, [created, requiresApproval, pendingReason, updated, deleted]);
 
     return null;
 }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -11,7 +11,7 @@
  * module once, so it effectively acts as a singleton per invocation.
  */
 
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@/prisma/generated";
 
 const globalForPrisma = globalThis as unknown as {
     prisma: PrismaClient | undefined;

--- a/src/lib/profanity-filter.ts
+++ b/src/lib/profanity-filter.ts
@@ -1,6 +1,7 @@
 /**
- * Censors profanity in user-generated text (e.g. direct messages, listings) by replacing matched words/phrases
- * with asterisks (same length as the match). Longer patterns are applied first.
+ * Censors profanity in user-generated text by replacing matched words/phrases
+ * with asterisks. Supports admin-defined blacklist (extra matches) and whitelist
+ * (allowed phrases/words skipped by the built-in list and blacklist).
  */
 
 function escapeRegExp(s: string): string {
@@ -100,32 +101,118 @@ const WORDS: string[] = [
 
 const ENTRIES = [...PHRASES, ...WORDS].sort((a, b) => b.length - a.length);
 
-const CENSOR_REGEXES: RegExp[] = ENTRIES.map((entry) => {
+export function buildEntryRegex(entry: string): RegExp {
     const parts = entry.trim().split(/\s+/).map(escapeRegExp);
     const body =
         parts.length === 1 ? `\\b${parts[0]}\\b` : `\\b${parts.join("\\s+")}\\b`;
     return new RegExp(body, "gi");
-});
+}
+
+const BUILTIN_LABELED: { label: string; re: RegExp }[] = ENTRIES.map((entry) => ({
+    label: entry,
+    re: buildEntryRegex(entry),
+}));
+
+const PLACEHOLDER_START = "\uE000";
+const PLACEHOLDER_END = "\uE001";
+
+function maskWhitelistSegments(
+    text: string,
+    whitelist: string[]
+): { masked: string; placeholders: Map<string, string> } {
+    const placeholders = new Map<string, string>();
+    const sorted = [...whitelist]
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .sort((a, b) => b.length - a.length);
+
+    let out = text;
+    let idx = 0;
+    for (const term of sorted) {
+        const re = buildEntryRegex(term);
+        out = out.replace(re, (match) => {
+            const key = `${PLACEHOLDER_START}WL${idx++}${PLACEHOLDER_END}`;
+            placeholders.set(key, match);
+            return key;
+        });
+    }
+    return { masked: out, placeholders };
+}
+
+function restoreWhitelistSegments(text: string, placeholders: Map<string, string>): string {
+    let out = text;
+    for (const [key, val] of placeholders) {
+        out = out.split(key).join(val);
+    }
+    return out;
+}
+
+function buildLabeledPatterns(
+    extraBlacklist: string[]
+): { label: string; re: RegExp }[] {
+    const extras = [...extraBlacklist]
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .sort((a, b) => b.length - a.length)
+        .map((entry) => ({
+            label: entry,
+            re: buildEntryRegex(entry),
+        }));
+    return [...BUILTIN_LABELED, ...extras];
+}
+
+export interface CensorProfanityOptions {
+    /** Phrases/words that must not be censored (e.g. academic or place names). */
+    whitelist?: string[];
+    /** Extra phrases/words to censor like the built-in list. */
+    blacklist?: string[];
+    /** When true, `matches` lists which patterns fired (built-in label or custom term). */
+    collectMatches?: boolean;
+}
 
 export interface CensorProfanityResult {
-    /** Text with matches replaced by asterisks (same length per match). */
     censored: string;
-    /** True if any pattern matched. */
     wasCensored: boolean;
+    /** Populated when `collectMatches` is true. */
+    matches?: string[];
 }
 
 /**
- * Returns a copy of `text` with profane words/phrases replaced by asterisks
- * (one asterisk per character in the match), and whether anything was censored.
+ * Returns censored text, whether anything was censored, and optional match labels.
  */
-export function censorProfanity(text: string): CensorProfanityResult {
-    let result = text;
+export function censorProfanity(text: string, options?: CensorProfanityOptions): CensorProfanityResult {
+    const whitelist = options?.whitelist ?? [];
+    const blacklist = options?.blacklist ?? [];
+    const collectMatches = options?.collectMatches ?? false;
+    const matches: string[] = [];
+
+    const { masked, placeholders } = maskWhitelistSegments(text, whitelist);
+    const labeled = buildLabeledPatterns(blacklist);
+
+    let result = masked;
     let wasCensored = false;
-    for (const re of CENSOR_REGEXES) {
+
+    for (const { label, re } of labeled) {
         result = result.replace(re, (match) => {
             wasCensored = true;
+            if (collectMatches) {
+                matches.push(label);
+            }
             return "*".repeat(match.length);
         });
     }
+
+    result = restoreWhitelistSegments(result, placeholders);
+
+    if (collectMatches && matches.length > 0) {
+        const seen = new Set<string>();
+        const deduped = matches.filter((m) => {
+            if (seen.has(m)) return false;
+            seen.add(m);
+            return true;
+        });
+        return { censored: result, wasCensored, matches: deduped };
+    }
+
     return { censored: result, wasCensored };
 }

--- a/src/lib/profanity-moderation-db.ts
+++ b/src/lib/profanity-moderation-db.ts
@@ -1,0 +1,39 @@
+import { prisma } from "@/lib/prisma";
+import { ProfanityListType } from "@prisma/client";
+
+type Cache = {
+    whitelist: string[];
+    blacklist: string[];
+    fetchedAt: number;
+};
+
+const TTL_MS = 30_000;
+let cache: Cache | null = null;
+
+export function invalidateProfanityModerationTermCache(): void {
+    cache = null;
+}
+
+export async function getProfanityModerationTermLists(): Promise<{
+    whitelist: string[];
+    blacklist: string[];
+}> {
+    const now = Date.now();
+    if (cache && now - cache.fetchedAt < TTL_MS) {
+        return { whitelist: cache.whitelist, blacklist: cache.blacklist };
+    }
+
+    const rows = await prisma.profanityModerationTerm.findMany({
+        select: { listType: true, term: true },
+    });
+
+    const whitelist = rows
+        .filter((r) => r.listType === ProfanityListType.WHITELIST)
+        .map((r) => r.term);
+    const blacklist = rows
+        .filter((r) => r.listType === ProfanityListType.BLACKLIST)
+        .map((r) => r.term);
+
+    cache = { whitelist, blacklist, fetchedAt: now };
+    return { whitelist, blacklist };
+}

--- a/src/models/ListingObject.ts
+++ b/src/models/ListingObject.ts
@@ -14,4 +14,9 @@ export type ListingObject = Omit<ListingWithRelations, "price"> & {
     price: number;
     isPendingApproval?: boolean;
     isDeniedByAdmin?: boolean;
+    /** When 18+ listing content is enabled, card/detail can show originals from the profanity review row. */
+    matureAlternateTitle?: string;
+    matureAlternateDescription?: string;
+    /** When a moderator cleared a profanity flag and the viewer has not opted in to mature content. */
+    blurProfanityReleasedCardImage?: boolean;
 };

--- a/src/types/admin/listings.ts
+++ b/src/types/admin/listings.ts
@@ -17,4 +17,5 @@ export interface PendingListing {
     category: string;
     price: string;
     date: string;
+    pendingReason: "FIRST_LISTING" | "PROFANITY" | "BOTH";
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*", "./generated/*"]
+      "@/*": ["./src/*"],
+      "@/prisma/*": ["./prisma/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
Listings with profanity: After a moderator clears them, they still go live with language censored in the catalog for everyone by default, and photos blurred on the listing view so the listing isn’t fully “in your face” until someone opts in.

Mature (18+) setting in account: In profile settings you can turn on a mature content option (off by default). When it’s on, you see those listings as originally written and photos unblurred; when it’s off, you keep the censored wording and blurred photos.

Market browse: The same idea applies on the main listing grid titles follow that mature setting, and thumbnails can blur for those moderated profanity listings when mature is off.

Unified admin pending approvals queue with reason + sorting: 
pulls all draft listings pending approval for either:

-first listing, or pending profanity flag

computes pendingReason as:
FIRST_LISTING
PROFANITY
BOTH

Admin listing profanity queue: Admins can sort flagged listings by date (newest or oldest or vice versa) to work through the pile in a sensible order.

Before you post a listing: While you type title and description, you get a heads-up if the text might be censored or sent for review, including what kinds of matches triggered it, so you’re not surprised after you submit.

Admin word lists: Admins can maintain a whitelist (things that should never be treated as profanity here) and a blacklist (extra words/phrases that should be treated like profanity), on a dedicated admin screen linked from the dashboard and the users/moderation area.

Dashboard: There’s a Profanity lists entry point so admins can get to that whitelist/blacklist screen quickly.

Listings that are withheld from posting no longer say "created successfully" now they say profanity hold, first listing hold, or both

When listings are in the midst of creation there is now a feature that will let you know before you submit or as you are typing that your listing may be flagged for profanity.